### PR TITLE
[chore] Run less go tests on macOS

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -10,7 +10,10 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest, macos-latest]
-        go-version: [1.18, 1.19]
+        go-version: [1.19]
+        include:
+          - os: ubuntu-latest
+            go-version: 1.18
     runs-on: ${{ matrix.os }}
     steps:
     - uses: actions/checkout@v3


### PR DESCRIPTION
This will ease the queue problem on macOS runners
