### PR TITLE
Use Node.js v18

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -6,7 +6,7 @@ RUN go mod download
 
 RUN go build -o /bin/bff
 
-FROM node:19.3.0-alpine3.17 as web-builder
+FROM node:18.21.1-alpine3.17 as web-builder
 
 WORKDIR /app
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -6,7 +6,7 @@ RUN go mod download
 
 RUN go build -o /bin/bff
 
-FROM node:18.21.1-alpine3.17 as web-builder
+FROM node:18.12.1-alpine3.17 as web-builder
 
 WORKDIR /app
 


### PR DESCRIPTION
Node.js v19.3.0 hangs when running on `arm/v7`, sticking to LTS solves the problem