### PR TITLE
Use full facebook/lexical repo name

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -19,7 +19,7 @@
       "matchSourceUrls": [
         "https://github.com/facebook/lexical"
       ],
-      "groupName": "@lexical monorepo"
+      "groupName": "facebook/lexical monorepo"
     }
   ],
   "postUpdateOptions": ["gomodTidy", "pnpmDedupe"]


### PR DESCRIPTION
Lexical appears to be a github username, not just as a package name... Use `facebook/lexical` to avoid spamming that user... Otherwise he may be notified every time Renovate updates the package.