### PR TITLE
Choose optimal address to send from

### DIFF
--- a/bff/config/config.go
+++ b/bff/config/config.go
@@ -3,6 +3,7 @@ package config
 import (
 	"os"
 	"path/filepath"
+	"strings"
 )
 
 var (
@@ -14,4 +15,7 @@ var (
 	AWS_SECRET_ACCESS_KEY    = os.Getenv("AWS_SECRET_ACCESS_KEY")
 	AWS_REGION               = os.Getenv("AWS_REGION")
 	AWS_API_ID               = os.Getenv("AWS_API_ID")
+
+	// comma separated list of domains, required for email replies
+	EMAIL_DOMAINS = strings.Split(os.Getenv("EMAIL_DOMAINS"), ",")
 )

--- a/bff/config/config.go
+++ b/bff/config/config.go
@@ -16,6 +16,6 @@ var (
 	AWS_REGION               = os.Getenv("AWS_REGION")
 	AWS_API_ID               = os.Getenv("AWS_API_ID")
 
-	// comma separated list of domains, required for email replies
-	EMAIL_DOMAINS = strings.Split(os.Getenv("EMAIL_DOMAINS"), ",")
+	// comma separated list of email addresses or domains, required for email replies
+	EMAIL_ADDRESSES = strings.Split(os.Getenv("EMAIL_ADDRESSES"), ",")
 )

--- a/bff/transport/rest/misc/config.go
+++ b/bff/transport/rest/misc/config.go
@@ -7,6 +7,6 @@ import (
 
 func Config(c *gin.Context) {
 	c.JSON(200, gin.H{
-		"emailDomains": config.EMAIL_DOMAINS,
+		"emailAddresses": config.EMAIL_ADDRESSES,
 	})
 }

--- a/bff/transport/rest/misc/config.go
+++ b/bff/transport/rest/misc/config.go
@@ -1,0 +1,12 @@
+package misc
+
+import (
+	"github.com/gin-gonic/gin"
+	"github.com/harryzcy/mailbox-browser/bff/config"
+)
+
+func Config(c *gin.Context) {
+	c.JSON(200, gin.H{
+		"emailDomains": config.EMAIL_DOMAINS,
+	})
+}

--- a/bff/transport/rest/router.go
+++ b/bff/transport/rest/router.go
@@ -36,6 +36,7 @@ func Init(logger *zap.Logger, mode string) *gin.Engine {
 	// misc routes
 	r.GET("/ping", misc.Ping)
 	r.GET("/info", misc.Info)
+	r.GET("/config", misc.Config)
 
 	r.NoRoute(func(c *gin.Context) {
 		if strings.HasPrefix(c.Request.URL.Path, "/assets/") {

--- a/web/src/contexts/ConfigContext.ts
+++ b/web/src/contexts/ConfigContext.ts
@@ -1,0 +1,36 @@
+import { createContext, Dispatch } from 'react'
+
+export interface Config {
+  emailAddresses: string[]
+}
+
+export interface State {
+  config: Config
+  loaded: boolean
+}
+
+export type Action = { type: 'set'; config: Config }
+
+export const initialConfigState: State = {
+  config: {
+    emailAddresses: []
+  },
+  loaded: false
+}
+
+export function configReducer(state: State, action: Action): State {
+  switch (action.type) {
+    case 'set':
+      return { config: action.config, loaded: true }
+    default:
+      return state
+  }
+}
+
+export const ConfigContext = createContext<{
+  state: State
+  dispatch: Dispatch<Action>
+}>({
+  state: initialConfigState,
+  dispatch: () => null
+})

--- a/web/src/pages/EmailRoot.tsx
+++ b/web/src/pages/EmailRoot.tsx
@@ -7,7 +7,9 @@ import { useContext, useEffect, useState } from 'react'
 import { Outlet, useOutletContext } from 'react-router-dom'
 import DraftEmailsTabs from '../components/emails/DraftEmailsTabs'
 import FullScreenContent from '../components/emails/FullScreenContent'
+import { ConfigContext } from '../contexts/ConfigContext'
 import { DraftEmailsContext } from '../contexts/DraftEmailContext'
+import { getConfig } from '../services/config'
 import { EmailInfo, listEmails, ListEmailsResponse } from '../services/emails'
 import { getCurrentYearMonth } from '../utils/time'
 
@@ -118,7 +120,23 @@ export default function EmailRoot(props: EmailRootProps) {
     loadEmails
   }
 
+  const configContext = useContext(ConfigContext)
   const draftEmailsContext = useContext(DraftEmailsContext)
+
+  const loadConfig = async () => {
+    if (configContext.state.loaded) {
+      return
+    }
+    const config = await getConfig()
+    configContext.dispatch({
+      type: 'set',
+      config
+    })
+  }
+
+  useEffect(() => {
+    loadConfig()
+  })
 
   return (
     <div className="flex-1 max-h-screen md:px-8 pt-2 md:pt-5">

--- a/web/src/pages/EmailView.tsx
+++ b/web/src/pages/EmailView.tsx
@@ -20,6 +20,7 @@ import { useOutsideClick } from '../hooks/useOutsideClick'
 import { EmailDraft } from '../components/emails/EmailDraft'
 import { DraftEmail, DraftEmailsContext } from '../contexts/DraftEmailContext'
 import { parseEmailContent } from '../utils/emails'
+import { ConfigContext } from '../contexts/ConfigContext'
 
 export default function EmailView() {
   const data = useLoaderData() as
@@ -35,13 +36,16 @@ export default function EmailView() {
     useContext(DraftEmailsContext)
   const [isInitialReplyOpen, setIsInitialReplyOpen] = useState(false)
 
+  const configContext = useContext(ConfigContext)
+
   const startReply = (email: Email) => {
     setIsInitialReplyOpen(true)
     dispatchDraftEmail({
       type: 'add',
       messageID: generateLocalDraftID(),
       isReply: true,
-      replyEmail: email
+      replyEmail: email,
+      allowedAddresses: configContext.state.config.emailAddresses
     })
   }
 

--- a/web/src/pages/Root.tsx
+++ b/web/src/pages/Root.tsx
@@ -2,28 +2,44 @@ import { useReducer } from 'react'
 import { Outlet } from 'react-router-dom'
 import Sidebar from '../components/Sidebar'
 import {
+  ConfigContext,
+  configReducer,
+  initialConfigState
+} from '../contexts/ConfigContext'
+import {
   draftEmailReducer,
   DraftEmailsContext,
   initialState
 } from '../contexts/DraftEmailContext'
 
 export default function Root() {
+  const [configState, configDispatch] = useReducer(
+    configReducer,
+    initialConfigState
+  )
   const [draftEmailsState, draftEmailsDispatch] = useReducer(
     draftEmailReducer,
     initialState
   )
 
   return (
-    <DraftEmailsContext.Provider
+    <ConfigContext.Provider
       value={{
-        emails: draftEmailsState.emails,
-        activeEmail: draftEmailsState.activeEmail,
-        updateWaitlist: draftEmailsState.updateWaitlist,
-        dispatch: draftEmailsDispatch
+        state: configState,
+        dispatch: configDispatch
       }}
     >
-      <Sidebar />
-      <Outlet />
-    </DraftEmailsContext.Provider>
+      <DraftEmailsContext.Provider
+        value={{
+          emails: draftEmailsState.emails,
+          activeEmail: draftEmailsState.activeEmail,
+          updateWaitlist: draftEmailsState.updateWaitlist,
+          dispatch: draftEmailsDispatch
+        }}
+      >
+        <Sidebar />
+        <Outlet />
+      </DraftEmailsContext.Provider>
+    </ConfigContext.Provider>
   )
 }

--- a/web/src/services/config.ts
+++ b/web/src/services/config.ts
@@ -1,0 +1,8 @@
+interface Config {
+  emailAddresses: string[]
+}
+
+export async function getConfig(): Promise<Config> {
+  const response = await fetch('/config')
+  return response.json()
+}

--- a/web/vite.config.ts
+++ b/web/vite.config.ts
@@ -8,6 +8,10 @@ export default defineConfig({
       '/web': {
         target: 'http://localhost:8070',
         changeOrigin: true
+      },
+      '/config': {
+        target: 'http://localhost:8070',
+        changeOrigin: true
       }
     }
   },


### PR DESCRIPTION
For email replies, choose the optimal address to send from based on configurations. The configuration is done in bff layer, and a list of email addresses or domains can be used.