### PR TITLE
Update read status in list view

### DIFF
--- a/web/src/pages/EmailRoot.tsx
+++ b/web/src/pages/EmailRoot.tsx
@@ -35,6 +35,7 @@ type InboxContext = {
     month: number
     nextCursor?: string
   }) => Promise<ListEmailsResponse>
+  markAsRead: (messageID: string) => void
 }
 
 interface EmailRootProps {
@@ -102,6 +103,20 @@ export default function EmailRoot(props: EmailRootProps) {
     setEmails(emails.filter((email) => email.messageID !== messageID))
   }
 
+  const markAsRead = (messageID: string) => {
+    setEmails(
+      emails.map((email) => {
+        if (email.messageID === messageID) {
+          return {
+            ...email,
+            unread: false
+          }
+        }
+        return email
+      })
+    )
+  }
+
   const outletContext: InboxContext = {
     count,
     setCount,
@@ -117,7 +132,8 @@ export default function EmailRoot(props: EmailRootProps) {
     setYear,
     month,
     setMonth,
-    loadEmails
+    loadEmails,
+    markAsRead
   }
 
   const configContext = useContext(ConfigContext)

--- a/web/src/pages/EmailView.tsx
+++ b/web/src/pages/EmailView.tsx
@@ -21,6 +21,7 @@ import { EmailDraft } from '../components/emails/EmailDraft'
 import { DraftEmail, DraftEmailsContext } from '../contexts/DraftEmailContext'
 import { parseEmailContent } from '../utils/emails'
 import { ConfigContext } from '../contexts/ConfigContext'
+import { useInboxContext } from './EmailRoot'
 
 export default function EmailView() {
   const data = useLoaderData() as
@@ -236,6 +237,14 @@ function EmailBlock(props: EmailBlockProps) {
   useOutsideClick(showMoreActionsRef, () => setShowMoreActions(false))
 
   const configContext = useContext(ConfigContext)
+
+  const { markAsRead } = useInboxContext()
+
+  useEffect(() => {
+    if (email.unread) {
+      markAsRead(email.messageID)
+    }
+  }, []) // only run once
 
   return (
     <>

--- a/web/src/services/emails.ts
+++ b/web/src/services/emails.ts
@@ -81,6 +81,7 @@ export type Email = {
   destination: string[]
   returnPath: string
   verdict: EmailVerdict
+  unread?: boolean
 
   // draft only
   timeUpdated: string


### PR DESCRIPTION
When an email is opened, update the read status in list view without refreshing the page.