### PR TITLE
Copy header when proxying

### DIFF
--- a/bff/transport/rest/proxy/proxy.go
+++ b/bff/transport/rest/proxy/proxy.go
@@ -33,6 +33,7 @@ func Proxy(ctx *gin.Context) {
 		ginutil.InternalError(ctx, err)
 		return
 	}
+	req.Header = ctx.Request.Header
 
 	res, err := client.Do(req)
 	if err != nil {


### PR DESCRIPTION
It will avoid some request errors