### PR TITLE
Handle some malformed img tags in email

### DIFF
--- a/web/src/utils/elements.ts
+++ b/web/src/utils/elements.ts
@@ -1,0 +1,34 @@
+export const globalAttributes = [
+  'accesskey',
+  'class',
+  'contenteditable',
+  'dir',
+  'draggable',
+  'enterkeyhint',
+  'hidden',
+  'id',
+  'inert',
+  'inputmode',
+  'lang',
+  'popover',
+  'spellcheck',
+  'style',
+  'tabindex',
+  'title',
+  'translate'
+]
+
+export const imgAttributes = [
+  'alt',
+  'crossorigin',
+  'height',
+  'ismap',
+  'loading',
+  'longdesc',
+  'referrerpolicy',
+  'sizes',
+  'src',
+  'srcset',
+  'usemap',
+  'width'
+]

--- a/web/src/utils/emails.tsx
+++ b/web/src/utils/emails.tsx
@@ -9,6 +9,8 @@ import parse, {
 
 import { type Email, type File } from 'services/emails'
 
+import { globalAttributes, imgAttributes } from './elements'
+
 export function getNameFromEmails(emails: string[] | null): string {
   if (!emails || emails.length === 0) {
     return ''
@@ -80,6 +82,8 @@ export function parseEmailContent(
             domNode.attribs.src = makeProxyURL(host, domNode.attribs.src)
           }
         }
+
+        domNode.attribs = filterElementAttributes(domNode.name, domNode.attribs)
       }
     }
   }
@@ -99,6 +103,23 @@ export function parseEmailContent(
       {email.text}
     </pre>
   )
+}
+
+function filterElementAttributes(
+  domName: Element['name'],
+  attribs: Element['attribs']
+): Element['attribs'] {
+  if (attribs === undefined) return attribs
+  if (domName === 'img') {
+    return Object.fromEntries(
+      Object.entries(attribs).filter(([key]) => {
+        if (globalAttributes.includes(key)) return true
+        if (imgAttributes.includes(key)) return true
+        return key.startsWith('data-')
+      })
+    )
+  }
+  return attribs
 }
 
 // containContentID returns true if there is a file with the given contentID


### PR DESCRIPTION
In one case, the email sender failed to escape some `"` in the image `alt` tag, causing many words being interpreted as attributes. i.e. for `<img alt="Some "words" />`, the `words` become an attribute. And these attributes are not allowed by React, and thus cause unexpected errors from the React runtime itself.

This PR is an attempt to filter `img` attributes before rendering.