### PR TITLE
Fix checkov lint for "Base64 High Entropy String"

### DIFF
--- a/bff/config/config_test.go
+++ b/bff/config/config_test.go
@@ -48,7 +48,7 @@ func TestLoad(t *testing.T) {
 	assert.Equal(t, "/static/index.html", IndexHTML)
 	assert.Equal(t, "us-west-2", AWSRegion)
 	assert.Equal(t, "example-key-id", AWSAccessKeyID)
-	assert.Equal(t, "example-secret-key", AWSSecretAccessKey)
+	assert.Equal(t, "example", AWSSecretAccessKey)
 	assert.Equal(t, "https://example.com", AWSAPIGatewayEndpoint)
 	assert.Equal(t, []string{"example.com", "example.org"}, EmailAddresses)
 	assert.True(t, ProxyEnable)

--- a/bff/testdata/config.yaml
+++ b/bff/testdata/config.yaml
@@ -1,7 +1,7 @@
 aws:
   region: us-west-2
   accessKeyID: example-key-id
-  secretAccessKey: example-secret-key
+  secretAccessKey: example
   apiGateway:
     apiID: app-id
     endpoint: https://example.com


### PR DESCRIPTION
To fix the following:
```
Check: CKV_SECRET_6: "Base64 High Entropy String"
	FAILED for resource: 31b17fd8b99f7d16ff642ef3638076fc1b4da08c
  	File: /bff/testdata/config.yaml:4-5
  	Guide: https://docs.prismacloud.io/en/enterprise-edition/policy-reference/secrets-policies/secrets-policy-index/git-secrets-6
  
  		4 |   secretAccessKey: exam**********
```