### PR TITLE
Fix email rendering issues

### DIFF
--- a/web/package-lock.json
+++ b/web/package-lock.json
@@ -26,6 +26,7 @@
         "@tailwindcss/vite": "4.2.2",
         "class-variance-authority": "0.7.1",
         "clsx": "2.1.1",
+        "domhandler": "6.0.1",
         "dompurify": "3.4.0",
         "html-react-parser": "6.0.1",
         "lexical": "0.43.0",

--- a/web/package.json
+++ b/web/package.json
@@ -30,6 +30,7 @@
     "@tailwindcss/vite": "4.2.2",
     "class-variance-authority": "0.7.1",
     "clsx": "2.1.1",
+    "domhandler": "6.0.1",
     "dompurify": "3.4.0",
     "html-react-parser": "6.0.1",
     "lexical": "0.43.0",

--- a/web/src/utils/elements.ts
+++ b/web/src/utils/elements.ts
@@ -83,7 +83,7 @@ export const allowedTags = [
 ]
 
 // Tags that should be removed from the document, without logging a warning.
-export const silenceTags = ['title', 'script']
+export const silenceTags = ['title', 'script', '!doctype']
 
 // Attributes that are allowed on all tags.
 export const globalAttributes = [

--- a/web/src/utils/elements.ts
+++ b/web/src/utils/elements.ts
@@ -83,7 +83,7 @@ export const allowedTags = [
 ]
 
 // Tags that should be removed from the document, without logging a warning.
-export const silenceTags = ['title', 'script', '!doctype']
+export const silenceTags = ['title', 'script']
 
 // Attributes that are allowed on all tags.
 export const globalAttributes = [

--- a/web/src/utils/emails.tsx
+++ b/web/src/utils/emails.tsx
@@ -1,4 +1,5 @@
 import * as css from '@adobe/css-tools'
+import { isTag, isText } from 'domhandler'
 import parse, {
   DOMNode,
   Element,
@@ -47,38 +48,39 @@ export function parseEmailContent(
   const options: HTMLReactParserOptions = {
     replace: (domNode: DOMNode) => {
       // DOMNode = Comment | Element | ProcessingInstruction | Text;
-      if (
-        domNode instanceof Comment ||
-        domNode instanceof ProcessingInstruction
-      ) {
-        return
-      }
-      if (domNode instanceof Text) {
+      if (isText(domNode)) {
         return domNode.data
       }
-      const element = domNode as Element
-      if (['html', 'head', 'body'].includes(element.name)) {
-        return <>{domToReact(element.children as DOMNode[], options)}</>
+      if (!isTag(domNode)) {
+        return
       }
-      if (!allowedTags.includes(element.name)) {
-        if (!silenceTags.includes(element.name)) {
-          console.warn(`Unsupported tag: ${element.name}`)
+      if (['html', 'head', 'body'].includes(domNode.name)) {
+        return <>{domToReact(domNode.children as DOMNode[], options)}</>
+      }
+      if (!domNode.name) {
+        console.warn('Element without name found, skipping')
+        console.warn(domNode.type)
+        return
+      }
+      if (!allowedTags.includes(domNode.name)) {
+        if (!silenceTags.includes(domNode.name)) {
+          console.warn(`Unsupported tag: ${domNode.name}`)
         }
         return <></>
       }
-      if (element.name === 'a') {
-        element.attribs.target = '_blank'
-        element.attribs.rel = 'noopener noreferrer'
+      if (domNode.name === 'a') {
+        domNode.attribs.target = '_blank'
+        domNode.attribs.rel = 'noopener noreferrer'
         return
       }
 
       // handle inline styles
-      if (element.attribs.style) {
-        element.attribs.style = transformStyles(host, element.attribs.style)
+      if (domNode.attribs.style) {
+        domNode.attribs.style = transformStyles(host, domNode.attribs.style)
       }
 
-      if (element.name === 'style') {
-        element.children = element.children
+      if (domNode.name === 'style') {
+        domNode.children = domNode.children
           .map((child) => {
             // nodeType 3 is text in domhandler package
             if (child.nodeType !== 3) return null
@@ -86,9 +88,9 @@ export function parseEmailContent(
           })
           .filter((child) => child !== null)
       }
-      if (element.name === 'img' && element.attribs.src) {
-        if (element.attribs.src.startsWith('cid:')) {
-          const cid = element.attribs.src.replace('cid:', '')
+      if (domNode.name === 'img' && domNode.attribs.src) {
+        if (domNode.attribs.src.startsWith('cid:')) {
+          const cid = domNode.attribs.src.replace('cid:', '')
           let disposition = ''
           if (containContentID(email.attachments, cid)) {
             disposition = 'attachments'
@@ -99,18 +101,18 @@ export function parseEmailContent(
           }
 
           if (disposition !== '') {
-            element.attribs.src = `${window.location.origin}/web/emails/${email.messageID}/${disposition}/${cid}`
+            domNode.attribs.src = `${window.location.origin}/web/emails/${email.messageID}/${disposition}/${cid}`
           }
         } else {
           if (!loadImage) {
-            element.attribs.src = ''
+            domNode.attribs.src = ''
           } else if (!disableProxy) {
-            element.attribs['data-original-src'] = element.attribs.src
-            element.attribs.src = makeProxyURL(host, element.attribs.src)
+            domNode.attribs['data-original-src'] = domNode.attribs.src
+            domNode.attribs.src = makeProxyURL(host, domNode.attribs.src)
           }
         }
 
-        element.attribs = filterElementAttributes(element.name, element.attribs)
+        domNode.attribs = filterElementAttributes(domNode.name, domNode.attribs)
       }
     }
   }

--- a/web/src/utils/emails.tsx
+++ b/web/src/utils/emails.tsx
@@ -57,11 +57,6 @@ export function parseEmailContent(
       if (['html', 'head', 'body'].includes(domNode.name)) {
         return <>{domToReact(domNode.children as DOMNode[], options)}</>
       }
-      if (!domNode.name) {
-        console.warn('Element without name found, skipping')
-        console.warn(domNode.type)
-        return
-      }
       if (!allowedTags.includes(domNode.name)) {
         if (!silenceTags.includes(domNode.name)) {
           console.warn(`Unsupported tag: ${domNode.name}`)

--- a/web/src/utils/emails.tsx
+++ b/web/src/utils/emails.tsx
@@ -46,29 +46,39 @@ export function parseEmailContent(
 
   const options: HTMLReactParserOptions = {
     replace: (domNode: DOMNode) => {
-      if (!(domNode instanceof Element)) return
-      if (['html', 'head', 'body'].includes(domNode.name)) {
-        return <>{domToReact(domNode.children as DOMNode[], options)}</>
+      // DOMNode = Comment | Element | ProcessingInstruction | Text;
+      if (
+        domNode instanceof Comment ||
+        domNode instanceof ProcessingInstruction
+      ) {
+        return
       }
-      if (!allowedTags.includes(domNode.name)) {
-        if (!silenceTags.includes(domNode.name)) {
-          console.warn(`Unsupported tag: ${domNode.name}`)
+      if (domNode instanceof Text) {
+        return domNode.data
+      }
+      const element = domNode as Element
+      if (['html', 'head', 'body'].includes(element.name)) {
+        return <>{domToReact(element.children as DOMNode[], options)}</>
+      }
+      if (!allowedTags.includes(element.name)) {
+        if (!silenceTags.includes(element.name)) {
+          console.warn(`Unsupported tag: ${element.name}`)
         }
         return <></>
       }
-      if (domNode.name === 'a') {
-        domNode.attribs.target = '_blank'
-        domNode.attribs.rel = 'noopener noreferrer'
+      if (element.name === 'a') {
+        element.attribs.target = '_blank'
+        element.attribs.rel = 'noopener noreferrer'
         return
       }
 
       // handle inline styles
-      if (domNode.attribs.style) {
-        domNode.attribs.style = transformStyles(host, domNode.attribs.style)
+      if (element.attribs.style) {
+        element.attribs.style = transformStyles(host, element.attribs.style)
       }
 
-      if (domNode.name === 'style') {
-        domNode.children = domNode.children
+      if (element.name === 'style') {
+        element.children = element.children
           .map((child) => {
             // nodeType 3 is text in domhandler package
             if (child.nodeType !== 3) return null
@@ -76,9 +86,9 @@ export function parseEmailContent(
           })
           .filter((child) => child !== null)
       }
-      if (domNode.name === 'img' && domNode.attribs.src) {
-        if (domNode.attribs.src.startsWith('cid:')) {
-          const cid = domNode.attribs.src.replace('cid:', '')
+      if (element.name === 'img' && element.attribs.src) {
+        if (element.attribs.src.startsWith('cid:')) {
+          const cid = element.attribs.src.replace('cid:', '')
           let disposition = ''
           if (containContentID(email.attachments, cid)) {
             disposition = 'attachments'
@@ -89,18 +99,18 @@ export function parseEmailContent(
           }
 
           if (disposition !== '') {
-            domNode.attribs.src = `${window.location.origin}/web/emails/${email.messageID}/${disposition}/${cid}`
+            element.attribs.src = `${window.location.origin}/web/emails/${email.messageID}/${disposition}/${cid}`
           }
         } else {
           if (!loadImage) {
-            domNode.attribs.src = ''
+            element.attribs.src = ''
           } else if (!disableProxy) {
-            domNode.attribs['data-original-src'] = domNode.attribs.src
-            domNode.attribs.src = makeProxyURL(host, domNode.attribs.src)
+            element.attribs['data-original-src'] = element.attribs.src
+            element.attribs.src = makeProxyURL(host, element.attribs.src)
           }
         }
 
-        domNode.attribs = filterElementAttributes(domNode.name, domNode.attribs)
+        element.attribs = filterElementAttributes(element.name, element.attribs)
       }
     }
   }


### PR DESCRIPTION
Using `instanceof` is not correct way to check DOM element types. This is breaking email rendering since some `domhandler` version upgrade. Instead, native methods exposed by `domhandler` should be used.