### PR TITLE
Disable preload and hide it behind a feature flag

### DIFF
--- a/web/src/services/emails.ts
+++ b/web/src/services/emails.ts
@@ -1,6 +1,8 @@
 import useSWR, { preload } from 'swr'
 import useSWRMutation, { TriggerWithArgs } from 'swr/mutation'
 
+import { ENABLE_PRELOAD } from 'utils/constants'
+
 export interface EmailInfo {
   messageID: string
   type: 'inbox' | 'draft' | 'sent'
@@ -123,6 +125,9 @@ export function useEmail(messageID: string | null): Email | undefined {
 }
 
 export async function preloadEmail(messageID: string): Promise<void> {
+  if (!ENABLE_PRELOAD) {
+    return
+  }
   await preload(`/web/emails/${messageID}`, emailFetcher)
 }
 

--- a/web/src/utils/constants.ts
+++ b/web/src/utils/constants.ts
@@ -1,1 +1,5 @@
 export const EMAIL_PRELOAD_DELAY = 500 // in milliseconds
+
+// Feature flags
+// eslint-disable-next-line @typescript-eslint/no-inferrable-types
+export const ENABLE_PRELOAD: boolean = false


### PR DESCRIPTION
The preload functionality has issues that it will mark an email as read automatically in AWS lambda functions. The feature should be disabled until there's a solution to it.