### PR TITLE
Allow docker cloudfront endpoint for builds

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -92,6 +92,7 @@ jobs:
             auth.docker.io:443
             github.com:443
             production.cloudflare.docker.com:443
+            production.cloudfront.docker.com:443
             proxy.golang.org:443
             registry-1.docker.io:443
             registry.npmjs.org:443


### PR DESCRIPTION
Docker added new CloudFront url to their allow list. The endpoint need to be updated in Harden Runner allowed endpoints to fix docker build. See docker/docs#25108