### PR TITLE
Upgrade dompurify to v3.4.11 [SECURITY]

### DIFF
--- a/web/package-lock.json
+++ b/web/package-lock.json
@@ -27,7 +27,7 @@
         "class-variance-authority": "0.7.1",
         "clsx": "2.1.1",
         "domhandler": "6.0.1",
-        "dompurify": "3.4.10",
+        "dompurify": "3.4.11",
         "html-react-parser": "6.1.3",
         "lexical": "0.45.0",
         "lucide-react": "1.20.0",
@@ -3266,9 +3266,9 @@
       }
     },
     "node_modules/dompurify": {
-      "version": "3.4.10",
-      "resolved": "https://registry.npmjs.org/dompurify/-/dompurify-3.4.10.tgz",
-      "integrity": "sha512-0xzNv0e7oYC6yyuOGZIABPM4qtg3QxLFniDNPP4ZP90wR8Yq3zgwpRbrNiT4N3IKqDbbYFEJLV+JWEs19aZ//w==",
+      "version": "3.4.11",
+      "resolved": "https://registry.npmjs.org/dompurify/-/dompurify-3.4.11.tgz",
+      "integrity": "sha512-zhlUV12GsaRzMsf9q5M254YhA4+VuF0fG+QFqu6aYpoGlKtz+w8//jBcGVYBgQkR5GHjUomejY84AV+/uPbWdw==",
       "license": "(MPL-2.0 OR Apache-2.0)",
       "optionalDependencies": {
         "@types/trusted-types": "^2.0.7"

--- a/web/package.json
+++ b/web/package.json
@@ -31,7 +31,7 @@
     "class-variance-authority": "0.7.1",
     "clsx": "2.1.1",
     "domhandler": "6.0.1",
-    "dompurify": "3.4.10",
+    "dompurify": "3.4.11",
     "html-react-parser": "6.1.3",
     "lexical": "0.45.0",
     "lucide-react": "1.20.0",


### PR DESCRIPTION
Manually upgrade to bypass npm `min-release-days` limit