### PR TITLE
Update nanoid to 3.3.18

### DIFF
--- a/web/package-lock.json
+++ b/web/package-lock.json
@@ -3809,9 +3809,9 @@
       "license": "MIT"
     },
     "node_modules/nanoid": {
-      "version": "3.3.17",
-      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.17.tgz",
-      "integrity": "sha512-xQLf0A3HOMlgHq0n247/LRuAOYmB7dXJ/DvAxGvsSBij45XtBSmQycu+F8ODbHwns/XyFZagyL1+J0Offw1E0g==",
+      "version": "3.3.18",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.18.tgz",
+      "integrity": "sha512-DTg4MJbGMWkfi6VZFdNt2/caMbQy4Ou+Op/hJQvGEWcnVfoA1QA+xzRKAzw9jD6+GVOOeYr/mIcuDSdug6F6+w==",
       "funding": [
         {
           "type": "github",


### PR DESCRIPTION
Fixes CVE-2026-67213 ([GHSA-2v37-7h3g-55p8](https://github.com/advisories/GHSA-2v37-7h3g-55p8), high, CWE-835): custom generators can loop indefinitely when size is zero.

Bumps nanoid 3.3.17 -> 3.3.18 in `web/package-lock.json`. Transitive dependency via `vite` > `postcss`, which already declares `nanoid: ^3.3.17`, so only the lockfile changes. `npm audit` in `web/` goes from 1 high to 0 vulnerabilities.