### PR TITLE
Remove unused web dependencies

### DIFF
--- a/web/package-lock.json
+++ b/web/package-lock.json
@@ -24,7 +24,6 @@
         "@lexical/utils": "0.49.0",
         "@radix-ui/react-toast": "1.2.23",
         "@tailwindcss/vite": "4.3.3",
-        "class-variance-authority": "0.7.1",
         "clsx": "2.1.1",
         "domhandler": "6.0.1",
         "dompurify": "3.4.13",
@@ -40,7 +39,6 @@
         "swr": "2.5.1",
         "tailwind-merge": "3.6.0",
         "tailwindcss": "4.3.3",
-        "tailwindcss-animate": "1.0.7",
         "yjs": "13.6.32"
       },
       "devDependencies": {
@@ -2951,18 +2949,6 @@
         "node": ">=18"
       }
     },
-    "node_modules/class-variance-authority": {
-      "version": "0.7.1",
-      "resolved": "https://registry.npmjs.org/class-variance-authority/-/class-variance-authority-0.7.1.tgz",
-      "integrity": "sha512-Ka+9Trutv7G8M6WT6SeiRWz792K5qEqIGEGzXKhAE6xOWAY6pPH8U+9IY3oCMv6kqTmLsv7Xh/2w2RigkePMsg==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "clsx": "^2.1.1"
-      },
-      "funding": {
-        "url": "https://polar.sh/cva"
-      }
-    },
     "node_modules/clsx": {
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/clsx/-/clsx-2.1.1.tgz",
@@ -4334,15 +4320,6 @@
       "resolved": "https://registry.npmjs.org/tailwindcss/-/tailwindcss-4.3.3.tgz",
       "integrity": "sha512-gOhV3P7ufE62QDGg1zVaTgCR+EtPv92k2nIhVcVKcLmxT1sUBsQGhnZj175j+MqRt4zLF7ic+sCYjfhxMxj7YQ==",
       "license": "MIT"
-    },
-    "node_modules/tailwindcss-animate": {
-      "version": "1.0.7",
-      "resolved": "https://registry.npmjs.org/tailwindcss-animate/-/tailwindcss-animate-1.0.7.tgz",
-      "integrity": "sha512-bl6mpH3T7I3UFxuvDEXLxy/VuFxBk5bbzplh7tXI68mwMokNYd1t9qPBHlnyTwfa4JGC4zP516I1hYYtQ/vspA==",
-      "license": "MIT",
-      "peerDependencies": {
-        "tailwindcss": ">=3.0.0 || insiders"
-      }
     },
     "node_modules/tapable": {
       "version": "2.3.3",

--- a/web/package.json
+++ b/web/package.json
@@ -28,7 +28,6 @@
     "@lexical/utils": "0.49.0",
     "@radix-ui/react-toast": "1.2.23",
     "@tailwindcss/vite": "4.3.3",
-    "class-variance-authority": "0.7.1",
     "clsx": "2.1.1",
     "domhandler": "6.0.1",
     "dompurify": "3.4.13",
@@ -44,7 +43,6 @@
     "swr": "2.5.1",
     "tailwind-merge": "3.6.0",
     "tailwindcss": "4.3.3",
-    "tailwindcss-animate": "1.0.7",
     "yjs": "13.6.32"
   },
   "devDependencies": {

--- a/web/src/index.css
+++ b/web/src/index.css
@@ -2,8 +2,6 @@
 
 @import 'tailwindcss';
 
-@plugin 'tailwindcss-animate';
-
 @custom-variant dark (&:is(.dark *));
 
 :root {


### PR DESCRIPTION
`class-variance-authority` was never imported. `tailwindcss-animate` was registered in `index.css` but no `animate-*` utility is used, and it is a Tailwind v3 plugin in a v4 project.