### PR TITLE
Bump minimum required Go version to 1.27

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM library/golang:1.26.6@sha256:0d1d3a794be25f809dd2cb3160d8c73276c4056a9f8242a138e908ddeee7b6b6 AS bff-builder
+FROM library/golang:1.27.0@sha256:65b6f280bf050ec5af12716857e8ea8439d694dbba8f31ceeb7630670071f2bb AS bff-builder
 
 ARG BUILD_VERSION
 ARG BUILD_COMMIT

--- a/bff/go.mod
+++ b/bff/go.mod
@@ -2,7 +2,7 @@ module github.com/harryzcy/mailbox-browser/bff
 
 go 1.25.0
 
-toolchain go1.26.6
+toolchain go1.27.0
 
 require (
 	github.com/aws/aws-sdk-go-v2 v1.43.7

--- a/bff/go.mod
+++ b/bff/go.mod
@@ -1,8 +1,6 @@
 module github.com/harryzcy/mailbox-browser/bff
 
-go 1.25.0
-
-toolchain go1.27.0
+go 1.27.0
 
 require (
 	github.com/aws/aws-sdk-go-v2 v1.43.7

--- a/bff/transport/rest/proxy/proxy.go
+++ b/bff/transport/rest/proxy/proxy.go
@@ -2,7 +2,6 @@ package proxy
 
 import (
 	"errors"
-	"net/http"
 	"net/http/httputil"
 	"net/url"
 
@@ -28,16 +27,13 @@ func Proxy(ctx *gin.Context) {
 		ginutil.InternalError(ctx, err)
 		return
 	}
-	proxy := httputil.NewSingleHostReverseProxy(&url.URL{
-		Scheme: remote.Scheme,
-		Host:   remote.Host,
-	})
-	proxy.Director = func(req *http.Request) {
-		req.Header = ctx.Request.Header
-		req.Host = remote.Host
-		req.URL.Scheme = remote.Scheme
-		req.URL.Host = remote.Host
-		req.URL.Path = remote.Path
+	proxy := &httputil.ReverseProxy{
+		Rewrite: func(req *httputil.ProxyRequest) {
+			req.Out.Host = remote.Host
+			req.Out.URL.Scheme = remote.Scheme
+			req.Out.URL.Host = remote.Host
+			req.Out.URL.Path = remote.Path
+		},
 	}
 
 	proxy.ServeHTTP(ctx.Writer, ctx.Request)


### PR DESCRIPTION
- Bump Go version to 1.27
- Replace deprecated API `(net/http/httputil.ReverseProxy).Director` with `Rewrite`

Replaces #3901 and #3919