### PR TITLE
Fix React lint errors from oxlint 1.79

### DIFF
--- a/web/src/components/emails/EmailMenuBar.tsx
+++ b/web/src/components/emails/EmailMenuBar.tsx
@@ -5,7 +5,7 @@ import {
   EnvelopeOpenIcon,
   TrashIcon
 } from '@heroicons/react/24/outline'
-import { useContext, useEffect, useState } from 'react'
+import { useContext, useState } from 'react'
 
 import { DraftEmailsContext } from 'contexts/DraftEmailContext'
 
@@ -48,13 +48,14 @@ export default function EmailMenuBar(props: EmailMenuBarProps) {
       <div className="hidden md:flex select-none items-stretch justify-between">
         <div className="flex items-center space-x-1">
           <ComposeButton />
-          <ActionBar
-            emailIDs={emailIDs}
-            handleDelete={handleDelete}
-            handleRead={handleRead}
-            handleUnread={handleUnread}
-            showOperations={showOperations}
-          />
+          {showOperations && (
+            <ActionBar
+              emailIDs={emailIDs}
+              handleDelete={handleDelete}
+              handleRead={handleRead}
+              handleUnread={handleUnread}
+            />
+          )}
         </div>
 
         <YearMonthNavigation
@@ -83,7 +84,6 @@ export default function EmailMenuBar(props: EmailMenuBarProps) {
                 handleDelete={handleDelete}
                 handleRead={handleRead}
                 handleUnread={handleUnread}
-                showOperations={showOperations}
               />
             </div>
           </>
@@ -159,23 +159,14 @@ function ActionBar(props: {
   handleDelete: () => void
   handleRead: () => void
   handleUnread: () => void
-  showOperations: boolean
 }) {
-  const { emailIDs, handleDelete, handleRead, handleUnread, showOperations } =
-    props
+  const { emailIDs, handleDelete, handleRead, handleUnread } = props
   const { config } = useConfig()
   const [showPluginMenu, setShowPluginMenu] = useState(false)
-  useEffect(() => {
-    setShowPluginMenu(false)
-  }, [showOperations])
 
   const invokePlugin = (plugin: Plugin) => {
     setShowPluginMenu(false)
     void plugins.invoke(plugin.name, emailIDs)
-  }
-
-  if (!showOperations) {
-    return null
   }
 
   return (

--- a/web/src/hooks/useThrottled.ts
+++ b/web/src/hooks/useThrottled.ts
@@ -1,4 +1,4 @@
-import { useCallback, useEffect, useRef, useState } from 'react'
+import { useEffect, useRef, useState } from 'react'
 
 const DEFAULT_THROTTLE_MS = 3000
 
@@ -14,37 +14,23 @@ const useThrottled = <T>(
   throttleMs: number = DEFAULT_THROTTLE_MS
 ) => {
   const [throttledValue, setThrottledValue] = useState(value)
-  const lastTriggered = useRef(Date.now())
-  const timeoutRef = useRef<ReturnType<typeof setTimeout> | null>(null)
-
-  const cancel = useCallback(() => {
-    if (timeoutRef.current) {
-      clearTimeout(timeoutRef.current)
-      timeoutRef.current = null
-    }
-  }, [])
+  const lastTriggered = useRef<number | null>(null)
 
   useEffect(() => {
-    let remainingTime = getRemainingTime(lastTriggered.current, throttleMs)
+    // The first effect run starts the throttle window; reading the clock here
+    // rather than during render keeps the render pure.
+    lastTriggered.current ??= Date.now()
 
-    if (remainingTime === 0) {
+    const remainingTime = getRemainingTime(lastTriggered.current, throttleMs)
+    const timeout = setTimeout(() => {
       lastTriggered.current = Date.now()
       setThrottledValue(value)
-      cancel()
-    } else {
-      timeoutRef.current ??= setTimeout(() => {
-        remainingTime = getRemainingTime(lastTriggered.current, throttleMs)
+    }, remainingTime)
 
-        if (remainingTime === 0) {
-          lastTriggered.current = Date.now()
-          setThrottledValue(value)
-          cancel()
-        }
-      }, remainingTime)
+    return () => {
+      clearTimeout(timeout)
     }
-
-    return cancel
-  }, [cancel, throttleMs, value])
+  }, [throttleMs, value])
 
   return throttledValue
 }

--- a/web/src/pages/EmailView.tsx
+++ b/web/src/pages/EmailView.tsx
@@ -105,8 +105,8 @@ export default function EmailView() {
   const draftElemRef = useRef<HTMLDivElement>(null)
 
   useEffect(() => {
-    if (!draftElemRef.current) return
-    draftElemRef.current.scrollIntoView()
+    if (!isInitialReplyOpen) return
+    draftElemRef.current?.scrollIntoView()
   }, [isInitialReplyOpen])
 
   const startForward = async (targetEmail: Email) => {

--- a/web/src/pages/EmailView.tsx
+++ b/web/src/pages/EmailView.tsx
@@ -104,9 +104,11 @@ export default function EmailView() {
 
   const draftElemRef = useRef<HTMLDivElement>(null)
 
+  // isInitialReplyOpen is a trigger, not a value this effect reads.
   useEffect(() => {
-    if (!isInitialReplyOpen) return
-    draftElemRef.current?.scrollIntoView()
+    if (!draftElemRef.current) return
+    draftElemRef.current.scrollIntoView()
+    // oxlint-disable-next-line react/exhaustive-effect-dependencies
   }, [isInitialReplyOpen])
 
   const startForward = async (targetEmail: Email) => {


### PR DESCRIPTION
## Why

`Oxlint / NPM Lint` has been failing on `main` since 8a02d1cc bumped oxlint 1.78.0 → 1.79.0, which surfaces `react/purity`, `react/set-state-in-effect`, and `react/exhaustive-effect-dependencies` — five errors across three files.

## Changes

| File | Rules | Fix |
|---|---|---|
| `web/src/hooks/useThrottled.ts` | `purity`, `set-state-in-effect` | Seed `Date.now()` in the effect rather than during render; emit via `setTimeout` instead of a synchronous `setState` |
| `web/src/components/emails/EmailMenuBar.tsx` | `set-state-in-effect`, `exhaustive-effect-dependencies` | Render `ActionBar` only when `showOperations`, so unmounting resets `showPluginMenu` and the reset effect can go |
| `web/src/pages/EmailView.tsx` | `exhaustive-effect-dependencies` | Suppressed on the dep array: `isInitialReplyOpen` is a trigger, not a value the effect reads |

All three preserve existing behavior. The only timing shift is in `useThrottled`, where an already-elapsed window now emits one macrotask later instead of within the same commit — not observable at the 3s default throttle.

## Out of scope

- `isInitialReplyOpen` is never reset to `false`, so only the first reply scrolls into view. Possibly deliberate, given the name.
