### PR TITLE
Add logo and favicon

### DIFF
--- a/web/index.html
+++ b/web/index.html
@@ -3,6 +3,7 @@
   <head>
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <link rel="icon" type="image/svg+xml" href="/src/assets/favicon.svg" />
     <title>Mailbox Browser</title>
   </head>
   <body>

--- a/web/src/assets/favicon.svg
+++ b/web/src/assets/favicon.svg
@@ -1,0 +1,10 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 32 32" width="32" height="32" role="img" aria-label="mailbox-browser">
+  <defs>
+    <linearGradient id="a" x1="0" y1="0" x2="32" y2="32" gradientUnits="userSpaceOnUse">
+      <stop offset="0" stop-color="#2563EB"/>
+      <stop offset="1" stop-color="#0EA5E9"/>
+    </linearGradient>
+  </defs>
+  <rect width="32" height="32" rx="7.2" fill="url(#a)"/>
+  <path fill="#fff" fill-rule="evenodd" clip-rule="evenodd" transform="translate(1 1) scale(1.25)" d="M4 12a8 8 0 0 1 16 0v6a2 2 0 0 1-2 2H6a2 2 0 0 1-2-2Zm3.2-1.6L12 14.2l4.8-3.8v3.2L12 17.4l-4.8-3.8Z"/>
+</svg>

--- a/web/src/assets/logo-mono.svg
+++ b/web/src/assets/logo-mono.svg
@@ -1,0 +1,3 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" width="24" height="24" role="img" aria-label="mailbox-browser">
+  <path fill="currentColor" fill-rule="evenodd" clip-rule="evenodd" d="M4 12a8 8 0 0 1 16 0v6a2 2 0 0 1-2 2H6a2 2 0 0 1-2-2Zm3.2-1.6L12 14.2l4.8-3.8v3.2L12 17.4l-4.8-3.8Z"/>
+</svg>

--- a/web/src/assets/logo.svg
+++ b/web/src/assets/logo.svg
@@ -1,0 +1,3 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" width="24" height="24" role="img" aria-label="mailbox-browser">
+  <path fill="#2563EB" fill-rule="evenodd" clip-rule="evenodd" d="M4 12a8 8 0 0 1 16 0v6a2 2 0 0 1-2 2H6a2 2 0 0 1-2-2Zm3.2-1.6L12 14.2l4.8-3.8v3.2L12 17.4l-4.8-3.8Z"/>
+</svg>


### PR DESCRIPTION
The app had a `<title>` and nothing else — no favicon, no avatar.

The mark is a curbside mailbox seen end-on, with an envelope flap cut out of the middle. One closed silhouette, so it holds at 16px in a browser tab and flattens to a single colour. Colours are the app's own: `#2563EB` (blue-600, the link colour) into `#0EA5E9` (sky-500).

- `web/src/assets/favicon.svg` — tile version, linked from `index.html`
- `web/src/assets/logo.svg` — flat `#2563EB`, for README and docs
- `web/src/assets/logo-mono.svg` — `currentColor`, for in-app use

Not `public/`: the bff only serves real files under `/assets/` (`bff/transport/rest/router.go:46`), so a root-level `/favicon.svg` would return `index.html` under Docker. Referencing it from `index.html` instead emits `/assets/favicon-[hash].svg`, which both deployments serve.
