### PR TITLE
Make the logo label project-neutral

### DIFF
--- a/web/src/assets/favicon.svg
+++ b/web/src/assets/favicon.svg
@@ -1,4 +1,4 @@
-<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 32 32" width="32" height="32" role="img" aria-label="mailbox-browser">
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 32 32" width="32" height="32" role="img" aria-label="Mailbox">
   <defs>
     <linearGradient id="a" x1="0" y1="0" x2="32" y2="32" gradientUnits="userSpaceOnUse">
       <stop offset="0" stop-color="#2563EB"/>

--- a/web/src/assets/logo-mono.svg
+++ b/web/src/assets/logo-mono.svg
@@ -1,3 +1,3 @@
-<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" width="24" height="24" role="img" aria-label="mailbox-browser">
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" width="24" height="24" role="img" aria-label="Mailbox">
   <path fill="currentColor" fill-rule="evenodd" clip-rule="evenodd" d="M4 12a8 8 0 0 1 16 0v6a2 2 0 0 1-2 2H6a2 2 0 0 1-2-2Zm3.2-1.6L12 14.2l4.8-3.8v3.2L12 17.4l-4.8-3.8Z"/>
 </svg>

--- a/web/src/assets/logo.svg
+++ b/web/src/assets/logo.svg
@@ -1,3 +1,3 @@
-<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" width="24" height="24" role="img" aria-label="mailbox-browser">
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" width="24" height="24" role="img" aria-label="Mailbox">
   <path fill="#2563EB" fill-rule="evenodd" clip-rule="evenodd" d="M4 12a8 8 0 0 1 16 0v6a2 2 0 0 1-2 2H6a2 2 0 0 1-2-2Zm3.2-1.6L12 14.2l4.8-3.8v3.2L12 17.4l-4.8-3.8Z"/>
 </svg>


### PR DESCRIPTION
The mark is shared with `harryzcy/mailbox`, so the SVGs shouldn't carry a label naming only this repo.

Label text only — the artwork is unchanged.
