### PR TITLE
Preload emails on mailbox v2.2.0+

### DIFF
--- a/web/src/components/emails/EmailTableRow.tsx
+++ b/web/src/components/emails/EmailTableRow.tsx
@@ -61,7 +61,6 @@ export default function EmailTableRow(props: EmailTableRowProps) {
     }
     setMouseOverDelayHandler(
       setTimeout(() => {
-        console.log('Preloading email', email.messageID)
         void preloadEmail(email.messageID)
       }, EMAIL_PRELOAD_DELAY)
     )

--- a/web/src/services/emails.ts
+++ b/web/src/services/emails.ts
@@ -1,7 +1,7 @@
 import useSWR, { preload } from 'swr'
 import useSWRMutation, { TriggerWithArgs } from 'swr/mutation'
 
-import { ENABLE_PRELOAD } from 'utils/constants'
+import { isFeatureEnabled } from 'services/featureFlags'
 
 export interface EmailInfo {
   messageID: string
@@ -125,7 +125,7 @@ export function useEmail(messageID: string | null): Email | undefined {
 }
 
 export async function preloadEmail(messageID: string): Promise<void> {
-  if (!ENABLE_PRELOAD) {
+  if (!(await isFeatureEnabled('preloadEmail'))) {
     return
   }
   await preload(`/web/emails/${messageID}`, emailFetcher)

--- a/web/src/services/featureFlags.test.ts
+++ b/web/src/services/featureFlags.test.ts
@@ -1,0 +1,31 @@
+import { describe, expect, it } from 'vitest'
+
+import { featureFlags, isFeatureEnabledFor } from 'services/featureFlags'
+
+describe('featureFlags', () => {
+  it('should gate preloadEmail on the Mailbox version', () => {
+    expect(featureFlags.preloadEmail).toEqual({
+      enabled: true,
+      minMailboxVersion: '2.2.0'
+    })
+  })
+})
+
+describe('isFeatureEnabledFor', () => {
+  it('should be true at or above the required version', () => {
+    expect(isFeatureEnabledFor('preloadEmail', 'v2.2.0')).toBe(true)
+    expect(isFeatureEnabledFor('preloadEmail', 'v2.2.1')).toBe(true)
+    expect(isFeatureEnabledFor('preloadEmail', 'v2.3.0')).toBe(true)
+  })
+
+  it('should be false below the required version', () => {
+    expect(isFeatureEnabledFor('preloadEmail', 'v2.1.0')).toBe(false)
+    expect(isFeatureEnabledFor('preloadEmail', 'v2.2.0-rc.1')).toBe(false)
+  })
+
+  it('should fail closed on an unknown version', () => {
+    const missing: string | undefined = undefined
+    expect(isFeatureEnabledFor('preloadEmail', missing)).toBe(false)
+    expect(isFeatureEnabledFor('preloadEmail', 'dev')).toBe(false)
+  })
+})

--- a/web/src/services/featureFlags.ts
+++ b/web/src/services/featureFlags.ts
@@ -1,0 +1,31 @@
+import { getInfo } from 'services/info'
+
+import { isVersionAtLeast } from 'utils/version'
+
+export const featureFlags = {
+  // Prefetch on hover. Needs harryzcy/mailbox#1221
+  preloadEmail: { enabled: true, minMailboxVersion: '2.2.0' }
+}
+
+export type FeatureName = keyof typeof featureFlags
+
+// An absent or unparseable Mailbox version fails closed.
+export function isFeatureEnabledFor(
+  name: FeatureName,
+  mailboxVersion: string | undefined
+): boolean {
+  const { enabled, minMailboxVersion } = featureFlags[name]
+  return (
+    enabled &&
+    mailboxVersion !== undefined &&
+    isVersionAtLeast(mailboxVersion, minMailboxVersion)
+  )
+}
+
+export async function isFeatureEnabled(name: FeatureName): Promise<boolean> {
+  try {
+    return isFeatureEnabledFor(name, (await getInfo()).version)
+  } catch {
+    return false
+  }
+}

--- a/web/src/services/info.ts
+++ b/web/src/services/info.ts
@@ -1,15 +1,23 @@
-import useSWR from 'swr'
+import useSWR, { preload } from 'swr'
 
-interface Info {
+export interface Info {
   build: string
   commit: string
   version: string
 }
 
+const INFO_KEY = 'info'
+
+const infoFetcher = async (): Promise<Info> => {
+  const response = await fetch('/web/info')
+  return response.json() as Promise<Info>
+}
+
 export function useInfo() {
-  const { data, error, isLoading } = useSWR<Info, Error>('info', async () => {
-    const response = await fetch('/web/info')
-    return response.json() as Promise<Info>
-  })
+  const { data, error, isLoading } = useSWR<Info, Error>(INFO_KEY, infoFetcher)
   return { data, error, isLoading }
+}
+
+export function getInfo(): Promise<Info> {
+  return Promise.resolve(preload<Info>(INFO_KEY, infoFetcher))
 }

--- a/web/src/utils/constants.ts
+++ b/web/src/utils/constants.ts
@@ -1,4 +1,1 @@
 export const EMAIL_PRELOAD_DELAY = 500 // in milliseconds
-
-// Feature flags
-export const ENABLE_PRELOAD: boolean = false

--- a/web/src/utils/version.test.ts
+++ b/web/src/utils/version.test.ts
@@ -1,0 +1,79 @@
+import { describe, expect, it } from 'vitest'
+
+import { compareVersions, isVersionAtLeast, parseVersion } from 'utils/version'
+
+describe('parseVersion', () => {
+  it('should parse a plain release, with or without the v prefix', () => {
+    expect(parseVersion('v2.2.0')).toEqual({
+      major: 2,
+      minor: 2,
+      patch: 0,
+      prerelease: null,
+      commitsAhead: 0
+    })
+    expect(parseVersion('2.2.0')).toEqual(parseVersion('v2.2.0'))
+  })
+
+  it('should parse a git describe suffix as commits past the tag', () => {
+    expect(parseVersion('v0.16.4-40-gf789eb67')).toEqual({
+      major: 0,
+      minor: 16,
+      patch: 4,
+      prerelease: null,
+      commitsAhead: 40
+    })
+  })
+
+  it('should parse a pre-release', () => {
+    expect(parseVersion('v2.3.0-rc.1')?.prerelease).toBe('rc.1')
+  })
+
+  it('should return null for untagged build placeholders', () => {
+    expect(parseVersion('dev')).toBeNull()
+    expect(parseVersion('n/a')).toBeNull()
+    expect(parseVersion('')).toBeNull()
+  })
+})
+
+describe('compareVersions', () => {
+  it('should order by major, minor, then patch', () => {
+    expect(compareVersions('2.2.0', '2.2.0')).toBe(0)
+    expect(compareVersions('2.2.1', '2.2.0')).toBe(1)
+    expect(compareVersions('2.3.0', '2.2.9')).toBe(1)
+    expect(compareVersions('1.11.0', '2.0.0')).toBe(-1)
+    expect(compareVersions('2.10.0', '2.9.0')).toBe(1)
+  })
+
+  it('should sort a pre-release before its release', () => {
+    expect(compareVersions('2.2.0-rc.1', '2.2.0')).toBe(-1)
+    expect(compareVersions('2.2.0', '2.2.0-rc.1')).toBe(1)
+  })
+
+  it('should sort commits past a tag after the tag', () => {
+    expect(compareVersions('2.2.0-5-gabcdef1', '2.2.0')).toBe(1)
+  })
+
+  it('should return null when either side is unparseable', () => {
+    expect(compareVersions('dev', '2.2.0')).toBeNull()
+    expect(compareVersions('2.2.0', 'dev')).toBeNull()
+  })
+})
+
+describe('isVersionAtLeast', () => {
+  it('should be true at the floor and above', () => {
+    expect(isVersionAtLeast('2.2.0', '2.2.0')).toBe(true)
+    expect(isVersionAtLeast('v2.2.0', '2.2.0')).toBe(true)
+    expect(isVersionAtLeast('v2.2.1', '2.2.0')).toBe(true)
+    expect(isVersionAtLeast('v2.3.0', '2.2.0')).toBe(true)
+    expect(isVersionAtLeast('v2.2.0-3-gabcdef1', '2.2.0')).toBe(true)
+  })
+
+  it('should be false below the floor', () => {
+    expect(isVersionAtLeast('2.1.0', '2.2.0')).toBe(false)
+    expect(isVersionAtLeast('v2.2.0-rc.1', '2.2.0')).toBe(false)
+  })
+
+  it('should fail closed on an unparseable version', () => {
+    expect(isVersionAtLeast('dev', '2.2.0')).toBe(false)
+  })
+})

--- a/web/src/utils/version.ts
+++ b/web/src/utils/version.ts
@@ -1,0 +1,67 @@
+export interface ParsedVersion {
+  major: number
+  minor: number
+  patch: number
+  // A pre-release such as `rc.1`, which sorts before the release.
+  prerelease: string | null
+  // Commits past the tag, from a `-40-gf789eb67` suffix.
+  commitsAhead: number
+}
+
+// Handles `v2.2.0`, pre-releases, and `git describe` output. Null if unparseable.
+export function parseVersion(raw: string): ParsedVersion | null {
+  let rest = raw.trim().replace(/^v/u, '')
+
+  let commitsAhead = 0
+  const described = /^(.*)-(\d+)-g[0-9a-f]{7,}$/u.exec(rest)
+  if (described) {
+    rest = described[1]
+    commitsAhead = Number(described[2])
+  }
+
+  const match = /^(\d+)\.(\d+)\.(\d+)(?:-([0-9A-Za-z.-]+))?$/u.exec(rest)
+  if (!match) {
+    return null
+  }
+
+  return {
+    major: Number(match[1]),
+    minor: Number(match[2]),
+    patch: Number(match[3]),
+    prerelease: match[4] ?? null,
+    commitsAhead
+  }
+}
+
+// Returns -1, 0 or 1, or null when either side can't be parsed.
+export function compareVersions(a: string, b: string): number | null {
+  const left = parseVersion(a)
+  const right = parseVersion(b)
+  if (!left || !right) {
+    return null
+  }
+
+  for (const part of ['major', 'minor', 'patch'] as const) {
+    if (left[part] !== right[part]) {
+      return left[part] < right[part] ? -1 : 1
+    }
+  }
+
+  // A pre-release sorts before the release it leads up to.
+  if (left.prerelease !== right.prerelease) {
+    if (left.prerelease === null) return 1
+    if (right.prerelease === null) return -1
+    return left.prerelease < right.prerelease ? -1 : 1
+  }
+
+  if (left.commitsAhead !== right.commitsAhead) {
+    return left.commitsAhead < right.commitsAhead ? -1 : 1
+  }
+  return 0
+}
+
+// `floor` or newer. Unparseable versions fail closed.
+export function isVersionAtLeast(version: string, floor: string): boolean {
+  const result = compareVersions(version, floor)
+  return result !== null && result >= 0
+}


### PR DESCRIPTION
Hovering an email now prefetches it. Opening it then feels instant.

Preloading needs mailbox v2.2.0 or newer. That's the first release that can fetch an email without marking it read (harryzcy/mailbox#1221). Older backends are unaffected. So are builds with no parseable version.

Unit tests cover version comparison and flag resolution.