### PR TITLE
Build the email editor from Lexical extensions

### DIFF
--- a/web/src/components/inputs/RichTextEditor.test.tsx
+++ b/web/src/components/inputs/RichTextEditor.test.tsx
@@ -1,6 +1,11 @@
 import { act, cleanup, render, screen } from '@testing-library/react'
 import type { LexicalEditor } from 'lexical'
-import { $createParagraphNode, $createTextNode, $getRoot } from 'lexical'
+import {
+  $createParagraphNode,
+  $createTextNode,
+  $getRoot,
+  HISTORY_PUSH_TAG
+} from 'lexical'
 import { afterEach, describe, expect, test, vi } from 'vitest'
 
 import RichTextEditor from './RichTextEditor'
@@ -18,6 +23,10 @@ function renderEditor(initialHtml = '') {
   )
 }
 
+function button(label: string): HTMLButtonElement {
+  return screen.getByLabelText(label) as HTMLButtonElement
+}
+
 function getEditor(): LexicalEditor {
   const element = screen.getByRole('textbox') as HTMLElement & {
     __lexicalEditor?: LexicalEditor
@@ -27,25 +36,64 @@ function getEditor(): LexicalEditor {
   return editor
 }
 
+function appendParagraph(editor: LexicalEditor, tag?: string) {
+  act(() => {
+    editor.update(
+      () => {
+        const paragraph = $createParagraphNode()
+        paragraph.append($createTextNode('typed'))
+        $getRoot().append(paragraph)
+      },
+      tag ? { discrete: true, tag } : { discrete: true }
+    )
+  })
+}
+
 describe('RichTextEditor', () => {
+  test('loads initialHtml into the editor', () => {
+    renderEditor('<p>hello draft</p>')
+    expect(screen.getByRole('textbox').textContent).toContain('hello draft')
+  })
+
+  test('shows the placeholder only while the editor is empty', () => {
+    renderEditor('')
+    expect(screen.getByText('Email body...')).toBeTruthy()
+    cleanup()
+
+    renderEditor('<p>hello draft</p>')
+    expect(screen.queryByText('Email body...')).toBeNull()
+  })
+
   // The toolbar reads the editor state to refresh its active formats, and that
   // read resolves computed styles to detect text direction. Without an editor
   // on the read it throws, and every later toolbar update is skipped.
   test('keeps refreshing the toolbar after an edit', () => {
     renderEditor('<p>hello draft</p>')
+    appendParagraph(getEditor())
+
+    expect(screen.getByRole('textbox').textContent).toContain('typed')
+  })
+
+  test('starts with undo and redo disabled', () => {
+    renderEditor('<p>hello draft</p>')
+    expect(button('Undo').disabled).toBe(true)
+    expect(button('Redo').disabled).toBe(true)
+  })
+
+  test('enables undo once the document changes', () => {
+    renderEditor('<p>hello draft</p>')
+    appendParagraph(getEditor(), HISTORY_PUSH_TAG)
+
+    expect(button('Undo').disabled).toBe(false)
+    expect(button('Redo').disabled).toBe(true)
+  })
+
+  test('ignores later initialHtml changes so typing is not discarded', () => {
+    renderEditor('<p>first</p>')
     const editor = getEditor()
+    appendParagraph(editor)
 
-    act(() => {
-      editor.update(
-        () => {
-          const paragraph = $createParagraphNode()
-          paragraph.append($createTextNode('typed'))
-          $getRoot().append(paragraph)
-        },
-        { discrete: true }
-      )
-    })
-
+    expect(getEditor()).toBe(editor)
     expect(screen.getByRole('textbox').textContent).toContain('typed')
   })
 })

--- a/web/src/components/inputs/RichTextEditor.tsx
+++ b/web/src/components/inputs/RichTextEditor.tsx
@@ -1,24 +1,20 @@
 import { CodeHighlightNode, CodeNode } from '@lexical/code'
+import { HistoryExtension } from '@lexical/history'
 import { $generateHtmlFromNodes, $generateNodesFromDOM } from '@lexical/html'
 import { AutoLinkNode, LinkNode } from '@lexical/link'
 import { ListItemNode, ListNode } from '@lexical/list'
 import { TRANSFORMERS } from '@lexical/markdown'
 import { AutoFocusPlugin } from '@lexical/react/LexicalAutoFocusPlugin'
-import {
-  InitialConfigType,
-  LexicalComposer
-} from '@lexical/react/LexicalComposer'
 import { ContentEditable } from '@lexical/react/LexicalContentEditable'
-import { LexicalErrorBoundary } from '@lexical/react/LexicalErrorBoundary'
-import { HistoryPlugin } from '@lexical/react/LexicalHistoryPlugin'
+import { LexicalExtensionComposer } from '@lexical/react/LexicalExtensionComposer'
 import { LinkPlugin } from '@lexical/react/LexicalLinkPlugin'
 import { ListPlugin } from '@lexical/react/LexicalListPlugin'
 import { MarkdownShortcutPlugin } from '@lexical/react/LexicalMarkdownShortcutPlugin'
 import { OnChangePlugin } from '@lexical/react/LexicalOnChangePlugin'
-import { RichTextPlugin } from '@lexical/react/LexicalRichTextPlugin'
-import { HeadingNode, QuoteNode } from '@lexical/rich-text'
+import { HeadingNode, QuoteNode, RichTextExtension } from '@lexical/rich-text'
 import { TableCellNode, TableNode, TableRowNode } from '@lexical/table'
-import { $getRoot, EditorState, LexicalEditor } from 'lexical'
+import { $getRoot, EditorState, LexicalEditor, defineExtension } from 'lexical'
+import { useState } from 'react'
 
 import { EmailQuoteNode } from 'components/inputs/EmailQuoteNode'
 import 'components/inputs/RichTextEditor.css'
@@ -28,12 +24,25 @@ import ListMaxIndentLevelPlugin from 'components/inputs/plugins/ListMaxIndentLev
 import ToolbarPlugin from 'components/inputs/plugins/ToolbarPlugin'
 import theme from 'components/inputs/themes/LexicalTheme'
 
+const PLACEHOLDER_TEXT = 'Email body...'
+
 function Placeholder() {
   return (
     <div className="pointer-events-none absolute top-3 left-3 inline-block truncate text-slate-400 select-none dark:text-neutral-400">
-      Email body...
+      {PLACEHOLDER_TEXT}
     </div>
   )
+}
+
+function updateHTML(editor: LexicalEditor, value: string, clear: boolean) {
+  const root = $getRoot()
+  const parser = new DOMParser()
+  const dom = parser.parseFromString(value, 'text/html')
+  const nodes = $generateNodesFromDOM(editor, dom)
+  if (clear) {
+    root.clear()
+  }
+  root.append(...nodes)
 }
 
 interface RichTextEditorProps {
@@ -44,42 +53,40 @@ interface RichTextEditorProps {
 }
 
 export default function RichTextEditor(props: RichTextEditorProps) {
-  const updateHTML = (editor: LexicalEditor, value: string, clear: boolean) => {
-    const root = $getRoot()
-    const parser = new DOMParser()
-    const dom = parser.parseFromString(value, 'text/html')
-    const nodes = $generateNodesFromDOM(editor, dom)
-    if (clear) {
-      root.clear()
-    }
-    root.append(...nodes)
-  }
-
-  const editorConfig: InitialConfigType = {
-    theme,
-    namespace: 'email-editor',
-    onError(error: Error) {
-      throw error
-    },
-    nodes: [
-      HeadingNode,
-      ListNode,
-      ListItemNode,
-      QuoteNode,
-      CodeNode,
-      CodeHighlightNode,
-      TableNode,
-      TableCellNode,
-      TableRowNode,
-      AutoLinkNode,
-      LinkNode,
-      EmailQuoteNode
-    ],
-    editorState: (editor) => {
-      if (!props.initialHtml) return
-      updateHTML(editor, props.initialHtml, true)
-    }
-  }
+  // Built once, on mount. The extension identity determines the editor's
+  // lifetime, and handleChange feeds the editor's own output back into
+  // initialHtml on every keystroke, so rebuilding on a new initialHtml would
+  // discard whatever the user had typed.
+  const [extension] = useState(() => {
+    const initialHtml = props.initialHtml
+    return defineExtension({
+      $initialEditorState: (editor: LexicalEditor) => {
+        if (!initialHtml) return
+        updateHTML(editor, initialHtml, true)
+      },
+      dependencies: [RichTextExtension, HistoryExtension],
+      name: '[root]',
+      namespace: 'email-editor',
+      nodes: [
+        HeadingNode,
+        ListNode,
+        ListItemNode,
+        QuoteNode,
+        CodeNode,
+        CodeHighlightNode,
+        TableNode,
+        TableCellNode,
+        TableRowNode,
+        AutoLinkNode,
+        LinkNode,
+        EmailQuoteNode
+      ],
+      onError(error: Error) {
+        throw error
+      },
+      theme
+    })
+  })
 
   const onChange = (_: EditorState, editor: LexicalEditor) => {
     editor.update(() => {
@@ -96,22 +103,17 @@ export default function RichTextEditor(props: RichTextEditorProps) {
   }
 
   return (
-    <LexicalComposer initialConfig={editorConfig}>
+    <LexicalExtensionComposer extension={extension} contentEditable={null}>
       <div className="relative flex size-full min-h-48 flex-col rounded text-left leading-5 font-normal md:rounded-md">
         <div className="relative flex-1 overflow-scroll overscroll-contain">
-          <RichTextPlugin
-            contentEditable={
-              <ContentEditable
-                className="relative min-h-full resize-none p-3 caret-inherit outline-hidden"
-                style={{
-                  tabSize: 1
-                }}
-              />
-            }
+          <ContentEditable
+            className="relative min-h-full resize-none p-3 caret-inherit outline-hidden"
+            style={{
+              tabSize: 1
+            }}
+            aria-placeholder={PLACEHOLDER_TEXT}
             placeholder={<Placeholder />}
-            ErrorBoundary={LexicalErrorBoundary}
           />
-          <HistoryPlugin />
           <OnChangePlugin onChange={onChange} ignoreSelectionChange />
           <AutoFocusPlugin />
           <CodeHighlightPlugin />
@@ -126,6 +128,6 @@ export default function RichTextEditor(props: RichTextEditorProps) {
           handleDelete={props.handleDelete}
         />
       </div>
-    </LexicalComposer>
+    </LexicalExtensionComposer>
   )
 }

--- a/web/src/components/inputs/plugins/ToolbarPlugin.tsx
+++ b/web/src/components/inputs/plugins/ToolbarPlugin.tsx
@@ -20,6 +20,7 @@ import {
   getDefaultCodeLanguage
 } from '@lexical/code'
 import { getCodeLanguages } from '@lexical/code-prism'
+import { HistoryExtension } from '@lexical/history'
 import { $isLinkNode, TOGGLE_LINK_COMMAND } from '@lexical/link'
 import {
   $isListNode,
@@ -29,6 +30,7 @@ import {
   REMOVE_LIST_COMMAND
 } from '@lexical/list'
 import { useLexicalComposerContext } from '@lexical/react/LexicalComposerContext'
+import { useExtensionSignalValue } from '@lexical/react/useExtensionSignalValue'
 import {
   $createHeadingNode,
   $createQuoteNode,
@@ -47,8 +49,6 @@ import {
   $getNodeByKey,
   $getSelection,
   $isRangeSelection,
-  CAN_REDO_COMMAND,
-  CAN_UNDO_COMMAND,
   FORMAT_ELEMENT_COMMAND,
   FORMAT_TEXT_COMMAND,
   LexicalEditor,
@@ -523,8 +523,8 @@ interface ToolbarPluginProps {
 export default function ToolbarPlugin(props: ToolbarPluginProps) {
   const [editor] = useLexicalComposerContext()
   const toolbarRef = useRef(null)
-  const [canUndo, setCanUndo] = useState(false)
-  const [canRedo, setCanRedo] = useState(false)
+  const canUndo = useExtensionSignalValue(HistoryExtension, 'canUndo')
+  const canRedo = useExtensionSignalValue(HistoryExtension, 'canRedo')
   const [blockType, setBlockType] = useState('paragraph')
   const [selectedElementKey, setSelectedElementKey] = useState<string | null>(
     null
@@ -603,22 +603,6 @@ export default function ToolbarPlugin(props: ToolbarPluginProps) {
         // eslint-disable-next-line @typescript-eslint/no-unused-vars
         (_payload, newEditor) => {
           updateToolbar()
-          return false
-        },
-        LowPriority
-      ),
-      editor.registerCommand(
-        CAN_UNDO_COMMAND,
-        (payload) => {
-          setCanUndo(payload)
-          return false
-        },
-        LowPriority
-      ),
-      editor.registerCommand(
-        CAN_REDO_COMMAND,
-        (payload) => {
-          setCanRedo(payload)
           return false
         },
         LowPriority


### PR DESCRIPTION
The email editor now builds from Lexical's extension API instead of the legacy composer, so the toolbar reads undo and redo availability from history signals rather than the deprecated commands.

Tests cover draft loading, the placeholder, undo state, and that typing never rebuilds the editor.