### PR TITLE
Fix email toolbar losing track of formatting state

### DIFF
--- a/web/src/components/inputs/RichTextEditor.test.tsx
+++ b/web/src/components/inputs/RichTextEditor.test.tsx
@@ -1,0 +1,51 @@
+import { act, cleanup, render, screen } from '@testing-library/react'
+import type { LexicalEditor } from 'lexical'
+import { $createParagraphNode, $createTextNode, $getRoot } from 'lexical'
+import { afterEach, describe, expect, test, vi } from 'vitest'
+
+import RichTextEditor from './RichTextEditor'
+
+afterEach(cleanup)
+
+function renderEditor(initialHtml = '') {
+  render(
+    <RichTextEditor
+      initialHtml={initialHtml}
+      handleChange={vi.fn<(value: { html: string; text: string }) => void>()}
+      handleSend={vi.fn<() => void>()}
+      handleDelete={vi.fn<() => void>()}
+    />
+  )
+}
+
+function getEditor(): LexicalEditor {
+  const element = screen.getByRole('textbox') as HTMLElement & {
+    __lexicalEditor?: LexicalEditor
+  }
+  const editor = element.__lexicalEditor
+  if (!editor) throw new Error('editor not attached to the content editable')
+  return editor
+}
+
+describe('RichTextEditor', () => {
+  // The toolbar reads the editor state to refresh its active formats, and that
+  // read resolves computed styles to detect text direction. Without an editor
+  // on the read it throws, and every later toolbar update is skipped.
+  test('keeps refreshing the toolbar after an edit', () => {
+    renderEditor('<p>hello draft</p>')
+    const editor = getEditor()
+
+    act(() => {
+      editor.update(
+        () => {
+          const paragraph = $createParagraphNode()
+          paragraph.append($createTextNode('typed'))
+          $getRoot().append(paragraph)
+        },
+        { discrete: true }
+      )
+    })
+
+    expect(screen.getByRole('textbox').textContent).toContain('typed')
+  })
+})

--- a/web/src/components/inputs/plugins/ToolbarPlugin.tsx
+++ b/web/src/components/inputs/plugins/ToolbarPlugin.tsx
@@ -589,9 +589,14 @@ export default function ToolbarPlugin(props: ToolbarPluginProps) {
   useEffect(() => {
     return mergeRegister(
       editor.registerUpdateListener(({ editorState }) => {
-        editorState.read(() => {
-          updateToolbar()
-        })
+        // {editor} is required: updateToolbar calls $isParentElementRTL, which
+        // needs an active editor to resolve computed styles.
+        editorState.read(
+          () => {
+            updateToolbar()
+          },
+          { editor }
+        )
       }),
       editor.registerCommand(
         SELECTION_CHANGE_COMMAND,


### PR DESCRIPTION
The email toolbar stopped refreshing after an edit, leaving the bold, italic, block type and link indicators showing stale state. Its text-direction check ran without an editor available and threw, which aborted the rest of the toolbar update.

Adds a regression test that fails on the previous behavior.